### PR TITLE
fix for wrong stimulus when intensities depend on local variables

### DIFF
--- a/phases.py
+++ b/phases.py
@@ -191,7 +191,7 @@ class Phase():
                 if type(intensity) is str:  # element[var] where var is a (local) variable
                     # We copy stimulus to avoid changing self.phase_lines[rowlbl].stimulus
                     # which would give wrong stimuli if variables change 
-                    stimulus = copy.copy( stimulus )
+                    stimulus = copy.copy(stimulus)
                     variables_both = Variables.join(self.global_variables, self.local_variables)
                     stimulus[element], err = ParseUtil.evaluate(intensity, variables=variables_both)
                     if err:

--- a/phases.py
+++ b/phases.py
@@ -186,9 +186,13 @@ class Phase():
             self._make_current_line(rowlbl)
 
         stimulus = self.phase_lines[rowlbl].stimulus
+        print(stimulus)
         if stimulus is not None:
             for element, intensity in stimulus.items():
                 if type(intensity) is str:  # element[var] where var is a (local) variable
+                    # We copy stimulus to avoid changing self.phase_lines[rowlbl].stimulus
+                    # which would give wrong stimuli if variables change 
+                    stimulus = copy.copy( stimulus )
                     variables_both = Variables.join(self.global_variables, self.local_variables)
                     stimulus[element], err = ParseUtil.evaluate(intensity, variables=variables_both)
                     if err:

--- a/phases.py
+++ b/phases.py
@@ -186,7 +186,6 @@ class Phase():
             self._make_current_line(rowlbl)
 
         stimulus = self.phase_lines[rowlbl].stimulus
-        print(stimulus)
         if stimulus is not None:
             for element, intensity in stimulus.items():
                 if type(intensity) is str:  # element[var] where var is a (local) variable


### PR DESCRIPTION
The `next_stimulus` in `phases.py` contains this code:

        stimulus = self.phase_lines[rowlbl].stimulus
        if stimulus is not None:
            for element, intensity in stimulus.items():
                if type(intensity) is str:  # element[var] where var is a (local) variable
                    variables_both = Variables.join(self.global_variables, self.local_variables)
                    stimulus[element], err = ParseUtil.evaluate(intensity, variables=variables_both)

But this causes a problem if intensities depend on local variables, because copy-by-reference will actually modify `self.phase_lines[rowlbl].stimulus` when assigning to `stimulus[element]`. This means that `stimulus` will have resolved values instead of variables, and if variable values change the stimulus will not be updated. It looks like the fix is easy, we just copy the stimulus if it contains variables:

        stimulus = self.phase_lines[rowlbl].stimulus
        if stimulus is not None:
            for element, intensity in stimulus.items():
                if type(intensity) is str:  # element[var] where var is a (local) variable
                    # We copy stimulus to avoid changing self.phase_lines[rowlbl].stimulus
                    # which would give wrong stimuli if variables change 
                    stimulus = copy.copy( stimulus )
                    variables_both = Variables.join(self.global_variables, self.local_variables)
                    stimulus[element], err = ParseUtil.evaluate(intensity, variables=variables_both)
