### PR TITLE
vwpn export in long form

### DIFF
--- a/docs/postprocessing.txt
+++ b/docs/postprocessing.txt
@@ -650,7 +650,7 @@ that affect the plot also affect the exported data (for example ``xscale``, ``ph
 
 In addition, the parameter :doc:`filename` is required to all exporting commands.
 
-The command :ref:`hexport` simply exports the sequence of alternating stimuli and responses for the ``@run`` specified with the parameter ``runlabel``. There is one sequence for each subject (regardless of the value of the parameter ``subject``). The exported data with ``@hexport`` is not affected by any other parameter.
+The command :ref:`hexport` exports the entire sequence of events for the ``@run`` specified with the parameter ``runlabel``. There is one sequence for each subject (regardless of the value of the parameter ``subject``). The exported data with ``@hexport`` is not affected by any other parameter.
 
 The destination file is specified with the parameter :doc:`filename`.
 
@@ -658,11 +658,26 @@ The destination file is specified with the parameter :doc:`filename`.
 
   If the specified file already exists, the existing file will be overwritten without warning.
 
+.. _format-of-the-csv-file-hexport
+
+Format of the csv-file for `@hexport`
+-------------------------------------
+
+The csv-file exported by :ref:`hexport` has one row for each event in the history, and the following columns:
+
+- run: The ``runlabel`` being exported.
+- phase: The ``phase`` in which the event occurred.
+- subject: The ``subject`` to which the event occurred.
+- step: The time step at which the event occurred. The time step is incremented only when stimuli are presented to the subject. If a phase has lines that do not present stimuli, there will be multiple rows with the same time step. See also the next two points.
+- line: The name of the phase line in which the event occurred.
+- stimuli: The stimuli being presented when the event occured, or the empty string if no stimuli were being presented. In other words, this field is identical to the stimulus field of the phase line at which the event occurred (see :doc:`phase-line`).
+- behavior: The behavior produced by the subject. 
+- Then follows a variable number of columns, each for one of the stimulus elements in the simulation, in the same order as in the ``stimulus_elements`` specification. Each column has the name of a stimulus element and its value is the intensity of that element at this specific stimulus presentation (see doc:`stimulus-specification`). If no intensity is specified, the intensity is 1. If the stimulus element was not presented, the intensity is 0.
 
 .. _format-of-the-csv-file:
 
-Format of the csv-file
-----------------------
+Format of the csv-file for `@vexport`, `@wexport`, `@pexport`, and `@nexport`
+-----------------------------------------------------------------------------
 
 The data export commands :ref:`vexport`, :ref:`wexport`, :ref:`pexport`, and :ref:`nexport`
 exports the data as a csv-file with two or more

--- a/docs/postprocessing.txt
+++ b/docs/postprocessing.txt
@@ -672,7 +672,8 @@ The csv-file exported by :ref:`hexport` has one row for each event in the histor
 - line: The name of the phase line in which the event occurred.
 - stimuli: The stimuli being presented when the event occured, or the empty string if no stimuli were being presented. In other words, this field is identical to the stimulus field of the phase line at which the event occurred (see :doc:`phase-line`).
 - behavior: The behavior produced by the subject. 
-- Then follows a variable number of columns, each for one of the stimulus elements in the simulation, in the same order as in the ``stimulus_elements`` specification. Each column has the name of a stimulus element and its value is the intensity of that element at this specific stimulus presentation (see doc:`stimulus-specification`). If no intensity is specified, the intensity is 1. If the stimulus element was not presented, the intensity is 0.
+- Then follows a set of columns, one for each stimulus elements in the simulation, in the same order as in the ``stimulus_elements`` specification. Each column has the name of a stimulus element and its value is the intensity of that element at this specific stimulus presentation (see doc:`stimulus-specification`). If no intensity is specified, the intensity is 1. If the stimulus element was not presented, the intensity is 0.
+- Then follows another set of columns, one for each global or local variable. When a variable value is not set, its value is reported as the string "NA" (for Not Available).
 
 .. _format-of-the-csv-file:
 

--- a/output.py
+++ b/output.py
@@ -196,11 +196,7 @@ class RunOutputSubject():
         self.phase_line_labels_steps = list()
 
     def write_history(self, stimulus, response):
-        stimulus_tuple = tuple([e for e in stimulus if stimulus[e] != 0])
-        if len(stimulus_tuple) == 1:
-            self.history.append(stimulus_tuple[0])
-        else:
-            self.history.append(stimulus_tuple)
+        self.history.append( stimulus )
         self.history.append(response)
 
     def write_step(self, phase_label, step):

--- a/output.py
+++ b/output.py
@@ -136,6 +136,10 @@ class RunOutput():
         self.output_subjects[subject_ind].write_phase_line_label(phase_line_label, step,
                                                                  preceeding_help_lines)
 
+    def write_variables(self, subject_ind, variables, step, preceding_help_line_variables):
+        self.output_subjects[subject_ind].write_variables(variables, step,
+                                                          preceding_help_line_variables)
+        
     def vwpn_eval(self, vwpn, expr, parameters, run_parameters):
         if vwpn in ('v', 'p') and not self.mechanism_obj.has_v():
             raise EvalException("Used mechanism does not have variable 'v'.")
@@ -195,6 +199,10 @@ class RunOutputSubject():
         # step numbers for help lines
         self.phase_line_labels_steps = list()
 
+        # List of variable values (managed like phase_line_labels
+        # because variables can change between steps)
+        self.variables = list()
+        
     def write_history(self, stimulus, response):
         self.history.append( stimulus )
         self.history.append(response)
@@ -211,6 +219,12 @@ class RunOutputSubject():
                 self.phase_line_labels_steps.append(step)
         self.phase_line_labels.append(phase_line_label)
         self.phase_line_labels_steps.append(step)
+
+    def write_variables(self, variables, step, preceding_help_line_variables):
+        if preceding_help_line_variables:
+            for variables in preceding_help_line_variables:
+                self.variables.append(variables)
+        self.variables.append(variables)
 
     def write_v(self, stimulus, response, step, mechanism):
         '''stimulus is a dict.'''

--- a/parsing.py
+++ b/parsing.py
@@ -1193,9 +1193,10 @@ class ExportCmd(PostCmd):
                 w.writerows( rows )
 
     def _vwpn_export(self, file, simulation_data):
+        run_label = self.parameters.get(kw.EVAL_RUNLABEL)
         with file as csvfile:
             w = csv.writer(csvfile, quotechar='"', quoting=csv.QUOTE_NONNUMERIC, escapechar=None)
-            w.writerow(['expr','subject','step','value'])
+            w.writerow(['run','expr','subject','step','value'])
 
             ydatas = []
             legend_labels = []
@@ -1236,7 +1237,7 @@ class ExportCmd(PostCmd):
                         subject_data = ydata[subject_ind]
                         subject_label = subject_ind + 1 # 1-based in CSV and figure output
                         for step in range(len(subject_data)):
-                            w.writerow( [legend_label, subject_label, step, subject_data[step]] )
+                            w.writerow( [run_label, legend_label, subject_label, step, subject_data[step]] )
                 else:
                     if eval_subject == kw.EVAL_AVERAGE:
                         subject_label = "average"
@@ -1246,7 +1247,7 @@ class ExportCmd(PostCmd):
                         # 'Internal error' because parameters have been checked already when parsing
                         raise EvalException(f"Internal error on eval_subject={eval_subject}.", self.lineno)
                     for step in range(len(ydata)):
-                        w.writerow( [legend_label, subject_label, step, ydata[step]] )
+                        w.writerow( [run_label, legend_label, subject_label, step, ydata[step]] )
 
     def progress_label(self):
         # return f"{self.cmd} {self.exprs0}"

--- a/parsing.py
+++ b/parsing.py
@@ -1158,31 +1158,35 @@ class ExportCmd(PostCmd):
                     while first_step_phase[1][p+1] <= step:
                         p += 1
                     phase = first_step_phase[0][p]
-                    stimulus = history[2*(step-1)]
-                    response = history[2*(step-1)+1]
-                    # Next loop figures out element intensities and
-                    # the compound representation of stimulus
-                    intensities = []
-                    compound = []
-                    for e in all_stimulus_elements:
-                        if e in stimulus:
-                            intensity = stimulus[e]
-                            intensities.append(intensity)
-                            if intensity==1:
-                                compound.append( f"{e}" )
+                    compound = [""]
+                    response = ""
+                    intensities = [""]*len(all_stimulus_elements)
+                    if i==len(phase_line_labels_steps)-1 or step != phase_line_labels_steps[i+1]:
+                        stimulus = history[2*(step-1)]
+                        response = history[2*(step-1)+1]
+                        # Next loop figures out element intensities and
+                        # the compound representation of stimulus
+                        intensities = []
+                        compound = []
+                        for e in all_stimulus_elements:
+                            if e in stimulus:
+                                intensity = stimulus[e]
+                                intensities.append(intensity)
+                                if intensity==1:
+                                    compound.append( f"{e}" )
+                                else:
+                                    compound.append( f"{e}[{intensity:g}]" )
                             else:
-                                compound.append( f"{e}[{intensity}]" )
-                        else:
-                            intensities.append(0)
+                                intensities.append(0)
                     # Saving variables must take care of keeping the
-                    # same order and adding 0 for variables that may
+                    # same order and adding NA for variables that may
                     # not have a value at this step
                     step_variables = list()
                     for v in all_variables:
                         if v in variables[i].values:
                             step_variables.append(variables[i].values[v])
                         else:
-                            step_variables.append("NA")
+                            step_variables.append("")
                     rows.append([run_label, phase, s, step, phase_line_labels[i], ','.join(compound), response] + intensities +
                                step_variables)
                 w.writerows( rows )

--- a/parsing.py
+++ b/parsing.py
@@ -1171,11 +1171,11 @@ class ExportCmd(PostCmd):
                         for e in all_stimulus_elements:
                             if e in stimulus:
                                 intensity = stimulus[e]
-                                intensities.append(intensity)
+                                intensities.append(f"{intensity:g}")
                                 if intensity==1:
-                                    compound.append( f"{e}" )
+                                    compound.append(f"{e}")
                                 else:
-                                    compound.append( f"{e}[{intensity:g}]" )
+                                    compound.append(f"{e}[{intensity:g}]")
                             else:
                                 intensities.append(0)
                     # Saving variables must take care of keeping the
@@ -1184,7 +1184,7 @@ class ExportCmd(PostCmd):
                     step_variables = list()
                     for v in all_variables:
                         if v in variables[i].values:
-                            step_variables.append(variables[i].values[v])
+                            step_variables.append(f"{variables[i].values[v]:g}")
                         else:
                             step_variables.append("")
                     rows.append([run_label, phase, s, step, phase_line_labels[i], ','.join(compound), response] + intensities +

--- a/parsing.py
+++ b/parsing.py
@@ -1160,7 +1160,7 @@ class ExportCmd(PostCmd):
                     phase = first_step_phase[0][p]
                     compound = [""]
                     response = ""
-                    intensities = [""]*len(all_stimulus_elements)
+                    intensities = [""] * len(all_stimulus_elements)
                     if i==len(phase_line_labels_steps)-1 or step != phase_line_labels_steps[i+1]:
                         stimulus = history[2*(step-1)]
                         response = history[2*(step-1)+1]
@@ -1171,11 +1171,11 @@ class ExportCmd(PostCmd):
                         for e in all_stimulus_elements:
                             if e in stimulus:
                                 intensity = stimulus[e]
-                                intensities.append(f"{intensity:g}")
+                                intensities.append(f"{intensity:.2g}")
                                 if intensity==1:
                                     compound.append(f"{e}")
                                 else:
-                                    compound.append(f"{e}[{intensity:g}]")
+                                    compound.append(f"{e}[{intensity:.2g}]")
                             else:
                                 intensities.append(0)
                     # Saving variables must take care of keeping the
@@ -1184,7 +1184,7 @@ class ExportCmd(PostCmd):
                     step_variables = list()
                     for v in all_variables:
                         if v in variables[i].values:
-                            step_variables.append(f"{variables[i].values[v]:g}")
+                            step_variables.append(f"{variables[i].values[v]:.2g}")
                         else:
                             step_variables.append("")
                     rows.append([run_label, phase, s, step, phase_line_labels[i], ','.join(compound), response] + intensities +

--- a/parsing.py
+++ b/parsing.py
@@ -1129,52 +1129,31 @@ class ExportCmd(PostCmd):
         with file as csvfile:
             w = csv.writer(csvfile, quotechar='"', quoting=csv.QUOTE_NONNUMERIC, escapechar=None)
 
-            # if self.eval_prop[EVAL_SUBJECT] == EVAL_ALL:
             run_label = self.parameters.get(kw.EVAL_RUNLABEL)
             n_subjects = len(simulation_data.run_outputs[run_label].output_subjects)
-            subject_legend_labels = list()
-            for i in range(n_subjects):
-                # subject_legend_labels.append("phase line subject {}".format(i))
-                subject_legend_labels.append("stimulus subject {}".format(i))
-                subject_legend_labels.append("response subject {}".format(i))
+            all_stimulus_elements = self.parameters.get(kw.STIMULUS_ELEMENTS)
 
             # Write headers
-            w.writerow(['step'] + subject_legend_labels)
-
-            # Write data
-            maxlen = 0
-
-            for i in range(n_subjects):
-                len_history_i = len(simulation_data.run_outputs[run_label].output_subjects[i].history)
-                if len_history_i > maxlen:
-                    maxlen = len_history_i
-            for histind in range(0, maxlen, 2):
-                datarow = [histind // 2]
-                for i in range(n_subjects):
-                    history = simulation_data.run_outputs[run_label].output_subjects[i].history
-                    # phase_line_labels = simulation_data.run_outputs[run_label].output_subjects[i].phase_line_labels
-                    # phase_line_labels_steps = simulation_data.run_outputs[run_label].output_subjects[i].phase_line_labels_steps
-                    # print(history)
-                    # print(phase_line_labels)
-                    # print(phase_line_labels_steps)
-                    if histind < len(history):
-                        stimulus = history[histind]
-                        response = history[histind + 1]
-                        # phase_line = phase_line_labels[]
-                        datarow.append(stimulus)
-                        datarow.append(response)
-                    else:
-                        datarow.append(' ')
-                        datarow.append(' ')
-                w.writerow(datarow)
-            # else:
-            #     # Write headers
-            #     w.writerow(['step', 'stimulus', 'response'])
-
-            #     # Write data
-            #     for row in range(len(ydata)):
-            #         datarow = [row, ydata[row]]
-            #         w.writerow(datarow)
+            w.writerow( ['run','subject','step'] + all_stimulus_elements + ['response'] )
+            
+            for s in range(n_subjects):
+                history = simulation_data.run_outputs[run_label].output_subjects[s].history
+                # phase_line_labels = simulation_data.run_outputs[run_label].output_subjects[i].phase_line_labels
+                # phase_line_labels_steps = simulation_data.run_outputs[run_label].output_subjects[i].phase_line_labels_steps
+                # print(history)
+                # print(phase_line_labels)
+                # print(phase_line_labels_steps)
+                for h in range(len(history) // 2):
+                    stimulus = history[2*h]
+                    response = history[2*h + 1]
+                    intensities = [len(all_stimulus_elements)]
+                    for e in all_stimulus_elements:
+                        if e in stimulus:
+                            intensities.append(stimulus[e])
+                        else:
+                            intensities.append(0)
+                    # phase_line = phase_line_labels[]
+                    w.writerow([run_label, s, h] + intensities + [response])
 
     def _vwpn_export(self, file, simulation_data):
         ydatas = []

--- a/parsing.py
+++ b/parsing.py
@@ -1134,7 +1134,7 @@ class ExportCmd(PostCmd):
             all_stimulus_elements = self.parameters.get(kw.STIMULUS_ELEMENTS)
 
             # Write headers
-            w.writerow( ['run','phase','subject','step','line','compound'] + all_stimulus_elements + ['behavior'] )
+            w.writerow(['run','phase','subject','step','line','compound','behavior'] + all_stimulus_elements)
             
             for s in range(n_subjects):
                 subject_output = simulation_data.run_outputs[run_label].output_subjects[s]
@@ -1162,7 +1162,7 @@ class ExportCmd(PostCmd):
                                 compound.append( f"{e}[{intensity}]" )
                         else:
                             intensities.append(0)
-                    w.writerow([run_label, phase, s, step, phase_line_labels[i], ','.join(compound)] + intensities + [response])
+                    w.writerow([run_label, phase, s, step, phase_line_labels[i], ','.join(compound), response] + intensities)
 
     def _vwpn_export(self, file, simulation_data):
         ydatas = []

--- a/parsing.py
+++ b/parsing.py
@@ -1134,7 +1134,7 @@ class ExportCmd(PostCmd):
             all_stimulus_elements = self.parameters.get(kw.STIMULUS_ELEMENTS)
 
             # Write headers
-            w.writerow(['run','phase','subject','step','line','compound','behavior'] + all_stimulus_elements)
+            w.writerow(['run','phase','subject','step','line','stimuli','behavior'] + all_stimulus_elements)
             
             for s in range(n_subjects):
                 subject_output = simulation_data.run_outputs[run_label].output_subjects[s]

--- a/parsing.py
+++ b/parsing.py
@@ -1177,7 +1177,7 @@ class ExportCmd(PostCmd):
                                 else:
                                     compound.append(f"{e}[{intensity:.2g}]")
                             else:
-                                intensities.append(0)
+                                intensities.append("0")
                     # Saving variables must take care of keeping the
                     # same order and adding NA for variables that may
                     # not have a value at this step

--- a/parsing.py
+++ b/parsing.py
@@ -1145,6 +1145,7 @@ class ExportCmd(PostCmd):
             w.writerow(['run','phase','subject','step','line','stimuli','behavior'] + all_stimulus_elements + all_variables)
             
             for s in range(n_subjects):
+                rows = list()
                 subject_output = simulation_data.run_outputs[run_label].output_subjects[s]
                 history = subject_output.history
                 phase_line_labels = subject_output.phase_line_labels
@@ -1182,8 +1183,9 @@ class ExportCmd(PostCmd):
                             step_variables.append(variables[i].values[v])
                         else:
                             step_variables.append("NA")
-                    w.writerow([run_label, phase, s, step, phase_line_labels[i], ','.join(compound), response] + intensities +
+                    rows.append([run_label, phase, s, step, phase_line_labels[i], ','.join(compound), response] + intensities +
                                step_variables)
+                w.writerows( rows )
 
     def _vwpn_export(self, file, simulation_data):
         ydatas = []

--- a/phases.py
+++ b/phases.py
@@ -192,6 +192,7 @@ class Phase():
             self._make_current_line(rowlbl)
 
         stimulus = self.phase_lines[rowlbl].stimulus
+        variables_both = Variables.join(self.global_variables, self.local_variables)
         if stimulus is not None:
             for element, intensity in stimulus.items():
                 if type(intensity) is str:  # element[var] where var is a (local) variable

--- a/phases.py
+++ b/phases.py
@@ -162,12 +162,10 @@ class Phase():
 
         if preceeding_help_lines is None:
             preceeding_help_lines = list()
-
-        if preceding_help_line_variables is None:
             preceding_help_line_variables = list()
 
         variables_both = Variables.join(self.global_variables, self.local_variables)
-
+               
         if not ignore_response_increment:
             # if not self.is_first_line:
             if response is not None:
@@ -175,10 +173,9 @@ class Phase():
                 self.event_counter.increment_count_line(response)
                 self.event_counter.set_last_response(response)
 
-
         if self.first_stimulus_presented:
             if self.stop_condition.is_met(variables_both, self.event_counter):
-                return None, None, preceeding_help_lines, None, variables_both, preceding_help_line_variables
+                return None, None, preceeding_help_lines, None, variables_both, None
 
         if self.is_first_line:
             # assert(response is None)
@@ -196,6 +193,9 @@ class Phase():
         if stimulus is not None:
             for element, intensity in stimulus.items():
                 if type(intensity) is str:  # element[var] where var is a (local) variable
+                    # We copy stimulus to avoid changing self.phase_lines[rowlbl].stimulus
+                    # which would give wrong stimuli if variables change 
+                    stimulus = copy.copy( stimulus )
                     stimulus[element], err = ParseUtil.evaluate(intensity, variables=variables_both)
                     if err:
                         raise ParseException(self.phase_lines[rowlbl].lineno, err)

--- a/simulation.py
+++ b/simulation.py
@@ -109,7 +109,7 @@ class Run():
                 if progress and progress.stop_clicked:
                     raise InterruptedSimulation()
                 next_stimulus_out = self.world.next_stimulus(response)
-                stimulus, phase_label, phase_line_label, preceeding_help_lines, omit_learn = next_stimulus_out
+                stimulus, phase_label, phase_line_label, preceeding_help_lines, omit_learn, variables, preceding_help_line_variables = next_stimulus_out
                 if progress:
                     if phase_label != prev_phase_label:  # Update phases progress
                         progress.increment2(self.run_label)
@@ -149,6 +149,8 @@ class Run():
                         step += 1
                     out.write_phase_line_label(subject_ind, phase_line_label, step,
                                                preceeding_help_lines)
+                    out.write_variables(subject_ind, variables, step,
+                                        preceding_help_line_variables)
                     last_stimulus = dict(stimulus)  # XXX dict ok?
                     last_response = response
                 else:

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -171,17 +171,17 @@ class TestGitHubIssues(LsTestCase):
 
         @variables x:1, n:2, y:3
         @run foo runlabel:n=2
-
-        @figure
-        @nplot e1
-        @nplot e2
+        
+        #@figure
+        #@nplot e1
+        #@nplot e2
         '''
         script, script_output = run(text)
         history = script_output.run_outputs["n=1"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e2'] * 9 + ['e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e2':1}] * 9 + [{'e1':1}])
 
         history = script_output.run_outputs["n=2"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e1', 'e2'] * 4 + ['e1', 'e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e1':1}, {'e2':1}] * 4 + [{'e1':1}, {'e1':1}])
 
         # Test that count_line(e1)=n is the same as count_line(A)=n
         text = '''
@@ -194,8 +194,8 @@ class TestGitHubIssues(LsTestCase):
         u                 : e1:10, e2:0
 
         @PHASE foo stop:e1=10
-        A e1   | count_line(A)=n: B | A
-        B e2   | A
+        A e1 | count_line(A)=n: B | A
+        B e2 | A
 
         @variables x:0, n:1
         @run foo runlabel:n=1
@@ -204,7 +204,7 @@ class TestGitHubIssues(LsTestCase):
         @run foo runlabel:n=2
 
         @variables x:1, n:20, y:3
-        @run foo runlabel:n=20
+        @run foo runlabel:n=3
 
         @figure
         @nplot e1
@@ -212,13 +212,13 @@ class TestGitHubIssues(LsTestCase):
         '''
         script, script_output = run(text)
         history = script_output.run_outputs["n=1"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e2'] * 9 + ['e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e2':1}] * 9 + [{'e1':1}])
 
         history = script_output.run_outputs["n=2"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e1', 'e2'] * 4 + ['e1', 'e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e1':1}, {'e2':1}] * 4 + [{'e1':1}, {'e1':1}])
 
-        history = script_output.run_outputs["n=20"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1'] * 10)
+        history = script_output.run_outputs["n=3"].output_subjects[0].history
+        self.assertEqual(history[0::2], [{'e1':1}] * 10)
 
         # Test that count_line(A)=n is the same as A=n
         text = '''
@@ -249,13 +249,13 @@ class TestGitHubIssues(LsTestCase):
         '''
         script, script_output = run(text)
         history = script_output.run_outputs["n=1"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e2'] * 9 + ['e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e2':1}] * 9 + [{'e1':1}])
 
         history = script_output.run_outputs["n=2"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e1', 'e2'] * 4 + ['e1', 'e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e1':1}, {'e2':1}] * 4 + [{'e1':1}, {'e1':1}])
 
         history = script_output.run_outputs["n=20"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1'] * 10)
+        self.assertEqual(history[0::2], [{'e1':1}] * 10)
 
         # Test that e1=n is the same as count_line(e1)=n
         text = '''
@@ -286,13 +286,13 @@ class TestGitHubIssues(LsTestCase):
         '''
         script, script_output = run(text)
         history = script_output.run_outputs["n=1"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e2'] * 9 + ['e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e2':1}] * 9 + [{'e1':1}])
 
         history = script_output.run_outputs["n=2"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e1', 'e2'] * 4 + ['e1', 'e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e1':1}, {'e2':1}] * 4 + [{'e1':1}, {'e1':1}])
 
         history = script_output.run_outputs["n=20"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1'] * 10)
+        self.assertEqual(history[0::2], [{'e1':1}] * 10)
 
         # Test that count_line(b)=n works
         text = '''
@@ -323,13 +323,13 @@ class TestGitHubIssues(LsTestCase):
         '''
         script, script_output = run(text)
         history = script_output.run_outputs["n=1"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e2'] * 9 + ['e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e2':1}] * 9 + [{'e1':1}])
 
         history = script_output.run_outputs["n=2"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1', 'e1', 'e2'] * 4 + ['e1', 'e1'])
+        self.assertEqual(history[0::2], [{'e1':1}, {'e1':1}, {'e2':1}] * 4 + [{'e1':1}, {'e1':1}])
 
         history = script_output.run_outputs["n=20"].output_subjects[0].history
-        self.assertEqual(history[0::2], ['e1'] * 10)
+        self.assertEqual(history[0::2], [{'e1':1}] * 10)
 
     def test_issue125(self):
         text = '''

--- a/tests/test_export_multi.py
+++ b/tests/test_export_multi.py
@@ -546,12 +546,12 @@ class TestExportMultiExpression(LsTestCase):
 
         exported_titles, exported_data = get_csv_file_contents(file_prop)
 
-        exported_titles_expected = ['expr','subject','step','value']
+        exported_titles_expected = ['run','expr','subject','step','value']
         self.assertListEqual(exported_titles, exported_titles_expected)
 
-        self.assertEqual(set(exprs), set([x[0] for x in exported_data]))
+        self.assertEqual(set(exprs), set([x[1] for x in exported_data]))
 
-        self.assertEqual(n_subjects, len(set([x[1] for x in exported_data])))
+        self.assertEqual(n_subjects, len(set([x[2] for x in exported_data])))
         
         pd = get_plot_data(figure_number=figure_number)
         self.assertPlotExportEqual(pd, exported_data)

--- a/tests/test_export_multi.py
+++ b/tests/test_export_multi.py
@@ -117,74 +117,43 @@ class TestExportMultiExpression(LsTestCase):
         vexport1_line = os.path.join('.', 'tests', 'exported_files', 'vexport1_line.txt')
         self.assertAlmostEqualFile(vexport1_prop, vexport1_line)
         exported_titles, exported_data = get_csv_file_contents(vexport1_prop)
-        self.assertListEqual(exported_titles, ["x", "v(stimulus->response)", "v(stimulus->no_response)"])
         pd = get_plot_data(figure_number=1)
-        self.assertPlotExportEqual(pd, ['v(stimulus->response)', 'v(stimulus->no_response)'],
-                                   exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
         vexport2_prop = os.path.join('.', 'tests', 'exported_files', 'vexport2_prop.txt')
         vexport2_line = os.path.join('.', 'tests', 'exported_files', 'vexport2_line.txt')
         self.assertAlmostEqualFile(vexport2_prop, vexport2_line)
         exported_titles, exported_data = get_csv_file_contents(vexport2_prop)
-        legends = ["x", "v(stimulus->response) subject 1", "v(stimulus->response) subject 2", "v(stimulus->response) subject 3", "v(stimulus->response) subject 4", "v(stimulus->response) subject 5", "v(stimulus->response) subject 6", "v(stimulus->response) subject 7", "v(stimulus->response) subject 8", "v(stimulus->response) subject 9", "v(stimulus->response) subject 10", "v(stimulus->no_response) subject 1", "v(stimulus->no_response) subject 2", "v(stimulus->no_response) subject 3", "v(stimulus->no_response) subject 4", "v(stimulus->no_response) subject 5", "v(stimulus->no_response) subject 6", "v(stimulus->no_response) subject 7", "v(stimulus->no_response) subject 8", "v(stimulus->no_response) subject 9", "v(stimulus->no_response) subject 10"]
-        self.assertListEqual(exported_titles, legends)
         pd = get_plot_data(figure_number=2)
-        self.assertPlotExportEqual(pd, legends[1:], exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
         wexport1_prop = os.path.join('.', 'tests', 'exported_files', 'wexport1_prop.txt')
         wexport1_line = os.path.join('.', 'tests', 'exported_files', 'wexport1_line.txt')
         self.assertAlmostEqualFile(wexport1_prop, wexport1_line)
         exported_titles, exported_data = get_csv_file_contents(wexport1_prop)
-        self.assertListEqual(exported_titles, ['x', 'w(background)', 'w(stimulus)', 'w(reward)'])
         pd = get_plot_data(figure_number=3)
-        self.assertPlotExportEqual(pd, ['w(background)', 'w(stimulus)', 'w(reward)'],
-                                   exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
         wexport2_prop = os.path.join('.', 'tests', 'exported_files', 'wexport2_prop.txt')
         wexport2_line = os.path.join('.', 'tests', 'exported_files', 'wexport2_line.txt')
         self.assertAlmostEqualFile(wexport2_prop, wexport2_line)
         exported_titles, exported_data = get_csv_file_contents(wexport2_prop)
-        legends = ["x", "w(background) subject 1", "w(background) subject 2", "w(background) subject 3", "w(background) subject 4", "w(background) subject 5", "w(background) subject 6", "w(background) subject 7", "w(background) subject 8", "w(background) subject 9", "w(background) subject 10", "w(stimulus) subject 1", "w(stimulus) subject 2", "w(stimulus) subject 3", "w(stimulus) subject 4", "w(stimulus) subject 5", "w(stimulus) subject 6", "w(stimulus) subject 7", "w(stimulus) subject 8", "w(stimulus) subject 9", "w(stimulus) subject 10", "w(reward) subject 1", "w(reward) subject 2", "w(reward) subject 3", "w(reward) subject 4", "w(reward) subject 5", "w(reward) subject 6", "w(reward) subject 7", "w(reward) subject 8", "w(reward) subject 9", "w(reward) subject 10"]
-        self.assertListEqual(exported_titles, legends)
         pd = get_plot_data(figure_number=4)
-        self.assertPlotExportEqual(pd, legends[1:], exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
         pexport1_prop = os.path.join('.', 'tests', 'exported_files', 'pexport1_prop.txt')
         pexport1_line = os.path.join('.', 'tests', 'exported_files', 'pexport1_line.txt')
         self.assertAlmostEqualFile(pexport1_prop, pexport1_line)
         exported_titles, exported_data = get_csv_file_contents(pexport1_prop)
-        legends = ["x", "p(stimulus[0.5],background[0.2]->response)", "p(reward[0.1],background[0.2]->no_response)"]
-        self.assertListEqual(exported_titles, legends)
         pd = get_plot_data(figure_number=5)
-        self.assertPlotExportEqual(pd, legends[1:], exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
         pexport2_prop = os.path.join('.', 'tests', 'exported_files', 'pexport2_prop.txt')
         pexport2_line = os.path.join('.', 'tests', 'exported_files', 'pexport2_line.txt')
         self.assertAlmostEqualFile(pexport2_prop, pexport2_line)
         exported_titles, exported_data = get_csv_file_contents(pexport2_prop)
-        legends = ["x", "p(stimulus[0.5],background[0.2]->response) subject 1",
-                        "p(stimulus[0.5],background[0.2]->response) subject 2",
-                        "p(stimulus[0.5],background[0.2]->response) subject 3",
-                        "p(stimulus[0.5],background[0.2]->response) subject 4",
-                        "p(stimulus[0.5],background[0.2]->response) subject 5",
-                        "p(stimulus[0.5],background[0.2]->response) subject 6",
-                        "p(stimulus[0.5],background[0.2]->response) subject 7",
-                        "p(stimulus[0.5],background[0.2]->response) subject 8",
-                        "p(stimulus[0.5],background[0.2]->response) subject 9",
-                        "p(stimulus[0.5],background[0.2]->response) subject 10",
-                        "p(reward[0.1],background[0.2]->no_response) subject 1",
-                        "p(reward[0.1],background[0.2]->no_response) subject 2",
-                        "p(reward[0.1],background[0.2]->no_response) subject 3",
-                        "p(reward[0.1],background[0.2]->no_response) subject 4",
-                        "p(reward[0.1],background[0.2]->no_response) subject 5",
-                        "p(reward[0.1],background[0.2]->no_response) subject 6",
-                        "p(reward[0.1],background[0.2]->no_response) subject 7",
-                        "p(reward[0.1],background[0.2]->no_response) subject 8",
-                        "p(reward[0.1],background[0.2]->no_response) subject 9",
-                        "p(reward[0.1],background[0.2]->no_response) subject 10"]
-        self.assertListEqual(exported_titles, legends)
         pd = get_plot_data(figure_number=6)
-        self.assertPlotExportEqual(pd, legends[1:], exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
     def test_semicolon_vss(self):
         text = """
@@ -224,22 +193,15 @@ class TestExportMultiExpression(LsTestCase):
         vssexport1_line = os.path.join('.', 'tests', 'exported_files', 'vssexport1_line.txt')
         self.assertAlmostEqualFile(vssexport1_prop, vssexport1_line)
         exported_titles, exported_data = get_csv_file_contents(vssexport1_prop)
-        self.assertListEqual(exported_titles, ["x", "vss(cs->us)", "vss(cs->cs)", "vss(us->cs)", "vss(us->us)"])
         pd = get_plot_data(figure_number=1)
-        self.assertPlotExportEqual(pd, ["vss(cs->us)", "vss(cs->cs)", "vss(us->cs)", "vss(us->us)"],
-                                   exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
         
         vssexport2_prop = os.path.join('.', 'tests', 'exported_files', 'vssexport2_prop.txt')
         vssexport2_line = os.path.join('.', 'tests', 'exported_files', 'vssexport2_line.txt')
         self.assertAlmostEqualFile(vssexport2_prop, vssexport2_line)
         exported_titles, exported_data = get_csv_file_contents(vssexport2_prop)
-        legends = ["x", "vss(cs->us) subject 1", "vss(cs->us) subject 2", "vss(cs->us) subject 3",
-                        "vss(cs->cs) subject 1", "vss(cs->cs) subject 2", "vss(cs->cs) subject 3",
-                        "vss(us->cs) subject 1", "vss(us->cs) subject 2", "vss(us->cs) subject 3",
-                        "vss(us->us) subject 1", "vss(us->us) subject 2", "vss(us->us) subject 3"]
-        self.assertListEqual(exported_titles, legends)
         pd = get_plot_data(figure_number=2)
-        self.assertPlotExportEqual(pd, legends[1:], exported_data)
+        self.assertPlotExportEqual(pd, exported_data)
 
     def test_asterisk_v(self):
         text = """
@@ -575,21 +537,21 @@ class TestExportMultiExpression(LsTestCase):
         self.checkExport('export2', n_subjects=3, exprs=exprs, figure_number=2)
 
     def checkExport(self, filename_base, n_subjects, exprs, figure_number):
-        exported_titles_expected = ['x']
-        if n_subjects == 1:
-            exported_titles_expected.extend(exprs)
-        else:
-            for expr in exprs:
-                for i in range(n_subjects):
-                    exported_titles_expected.append(expr + ' subject ' + str(i + 1))
-
         file_prop = filename_base + '_prop.txt'
         file_line = filename_base + '_line.txt'
 
         file_prop = os.path.join('.', 'tests', 'exported_files', file_prop)
         file_line = os.path.join('.', 'tests', 'exported_files', file_line)
         self.assertAlmostEqualFile(file_prop, file_line)
+
         exported_titles, exported_data = get_csv_file_contents(file_prop)
+
+        exported_titles_expected = ['expr','subject','step','value']
         self.assertListEqual(exported_titles, exported_titles_expected)
+
+        self.assertEqual(set(exprs), set([x[0] for x in exported_data]))
+
+        self.assertEqual(n_subjects, len(set([x[1] for x in exported_data])))
+        
         pd = get_plot_data(figure_number=figure_number)
-        self.assertPlotExportEqual(pd, exported_titles_expected[1:], exported_data)
+        self.assertPlotExportEqual(pd, exported_data)

--- a/tests/test_hexport.py
+++ b/tests/test_hexport.py
@@ -39,26 +39,16 @@ class TestHExport(LsTestCase):
 
         @hexport ./tests/exported_files/test_issue_57.txt
         '''
-        successful_attempt = False
-        while not successful_attempt:
-            run(text)
-            self.assert_exported_files_exist([file])
-            last_row = None
-            with open(filepath) as csv_file:
-                csv_reader = csv.reader(csv_file, delimiter=',')
-                for row in csv_reader:
-                    last_row = row
-            successful_attempt = (' ' in last_row)
-        self.assertEqual(last_row.count(' '), 2)
-
+        run(text)
         with open(filepath) as csv_file:
             csv_reader = csv.reader(csv_file, delimiter=',')
             line_count = 0
+            expected_header = ['run','phase','subject','step','line','compound','behavior','s1','s2']
             for row in csv_reader:
                 if line_count == 0:
-                    self.assertEqual(row, ["step", "stimulus subject 0", "response subject 0", "stimulus subject 1", "response subject 1"])
+                    self.assertEqual(row, expected_header )
                 else:
-                    self.assertEqual(len(row), 5)
+                    self.assertEqual(len(row), len(expected_header))
                 line_count += 1
 
 

--- a/tests/test_hexport.py
+++ b/tests/test_hexport.py
@@ -43,7 +43,7 @@ class TestHExport(LsTestCase):
         with open(filepath) as csv_file:
             csv_reader = csv.reader(csv_file, delimiter=',')
             line_count = 0
-            expected_header = ['run','phase','subject','step','line','compound','behavior','s1','s2']
+            expected_header = ['run','phase','subject','step','line','stimuli','behavior','s1','s2']
             for row in csv_reader:
                 if line_count == 0:
                     self.assertEqual(row, expected_header )

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -409,7 +409,7 @@ class TestRescorlaWagner(LsTestCase):
 
         self.assertIsNotNone(data)
 
-        expected_file_contents = '''"run","phase","subject","step","line","compound","behavior","cs","us"
+        expected_file_contents = '''"run","phase","subject","step","line","stimuli","behavior","cs","us"
 "run1","foo",0,1,"CS","cs","",1,0
 "run1","foo",0,2,"US","us","",0,1
 "run1","foo",0,3,"CS","cs","",1,0

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -410,15 +410,15 @@ class TestRescorlaWagner(LsTestCase):
         self.assertIsNotNone(data)
 
         expected_file_contents = '''"run","phase","subject","step","line","stimuli","behavior","cs","us"
-"run1","foo",0,1,"CS","cs","","1","0"
-"run1","foo",0,2,"US","us","","0","1"
-"run1","foo",0,3,"CS","cs","","1","0"
-"run1","foo",0,4,"US","us","","0","1"
-"run1","foo",0,5,"CS","cs","","1","0"
-"run1","foo",0,6,"US","us","","0","1"
-"run1","foo",0,7,"CS","cs","","1","0"
-"run1","foo",0,8,"US","us","","0","1"
-"run1","foo",0,9,"CS","cs","","1","0"
+"run1","foo",1,1,"CS","cs","","1","0"
+"run1","foo",1,2,"US","us","","0","1"
+"run1","foo",1,3,"CS","cs","","1","0"
+"run1","foo",1,4,"US","us","","0","1"
+"run1","foo",1,5,"CS","cs","","1","0"
+"run1","foo",1,6,"US","us","","0","1"
+"run1","foo",1,7,"CS","cs","","1","0"
+"run1","foo",1,8,"US","us","","0","1"
+"run1","foo",1,9,"CS","cs","","1","0"
 '''
         self.assertEqual(data, expected_file_contents)
         filenames = ['test_rw_hexport.txt']
@@ -452,25 +452,25 @@ class TestRescorlaWagner(LsTestCase):
 
         self.assertIsNotNone(data)
 
-        expected_file_contents = '''"x","n(b1)"
-0,0.0
-1,0.0
-2,0.0
-3,0.0
-4,0.0
-5,0.0
-6,0.0
-7,0.0
-8,0.0
-9,0.0
-10,0.0
-11,0.0
-12,0.0
-13,0.0
-14,0.0
-15,0.0
-16,0.0
-17,0.0
+        expected_file_contents = '''"run","expr","subject","step","value"
+"run1","n(b1)","average",0,0.0
+"run1","n(b1)","average",1,0.0
+"run1","n(b1)","average",2,0.0
+"run1","n(b1)","average",3,0.0
+"run1","n(b1)","average",4,0.0
+"run1","n(b1)","average",5,0.0
+"run1","n(b1)","average",6,0.0
+"run1","n(b1)","average",7,0.0
+"run1","n(b1)","average",8,0.0
+"run1","n(b1)","average",9,0.0
+"run1","n(b1)","average",10,0.0
+"run1","n(b1)","average",11,0.0
+"run1","n(b1)","average",12,0.0
+"run1","n(b1)","average",13,0.0
+"run1","n(b1)","average",14,0.0
+"run1","n(b1)","average",15,0.0
+"run1","n(b1)","average",16,0.0
+"run1","n(b1)","average",17,0.0
 '''
         self.assertEqual(data, expected_file_contents)
         filenames = ['test_rw_hexport.txt']
@@ -486,25 +486,25 @@ class TestRescorlaWagner(LsTestCase):
 
         self.assertIsNotNone(data)
 
-        expected_file_contents = '''"x","n(cs)"
-0,1.0
-1,1.0
-2,1.0
-3,1.0
-4,2.0
-5,2.0
-6,2.0
-7,2.0
-8,3.0
-9,3.0
-10,3.0
-11,3.0
-12,4.0
-13,4.0
-14,4.0
-15,4.0
-16,5.0
-17,5.0
+        expected_file_contents = '''"run","expr","subject","step","value"
+"run1","n(cs)","average",0,1.0
+"run1","n(cs)","average",1,1.0
+"run1","n(cs)","average",2,1.0
+"run1","n(cs)","average",3,1.0
+"run1","n(cs)","average",4,2.0
+"run1","n(cs)","average",5,2.0
+"run1","n(cs)","average",6,2.0
+"run1","n(cs)","average",7,2.0
+"run1","n(cs)","average",8,3.0
+"run1","n(cs)","average",9,3.0
+"run1","n(cs)","average",10,3.0
+"run1","n(cs)","average",11,3.0
+"run1","n(cs)","average",12,4.0
+"run1","n(cs)","average",13,4.0
+"run1","n(cs)","average",14,4.0
+"run1","n(cs)","average",15,4.0
+"run1","n(cs)","average",16,5.0
+"run1","n(cs)","average",17,5.0
 '''
         self.assertEqual(data, expected_file_contents)
         filenames = ['test_rw_hexport.txt']

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -410,15 +410,15 @@ class TestRescorlaWagner(LsTestCase):
         self.assertIsNotNone(data)
 
         expected_file_contents = '''"run","phase","subject","step","line","stimuli","behavior","cs","us"
-"run1","foo",0,1,"CS","cs","",1,0
-"run1","foo",0,2,"US","us","",0,1
-"run1","foo",0,3,"CS","cs","",1,0
-"run1","foo",0,4,"US","us","",0,1
-"run1","foo",0,5,"CS","cs","",1,0
-"run1","foo",0,6,"US","us","",0,1
-"run1","foo",0,7,"CS","cs","",1,0
-"run1","foo",0,8,"US","us","",0,1
-"run1","foo",0,9,"CS","cs","",1,0
+"run1","foo",0,1,"CS","cs","","1","0"
+"run1","foo",0,2,"US","us","","0","1"
+"run1","foo",0,3,"CS","cs","","1","0"
+"run1","foo",0,4,"US","us","","0","1"
+"run1","foo",0,5,"CS","cs","","1","0"
+"run1","foo",0,6,"US","us","","0","1"
+"run1","foo",0,7,"CS","cs","","1","0"
+"run1","foo",0,8,"US","us","","0","1"
+"run1","foo",0,9,"CS","cs","","1","0"
 '''
         self.assertEqual(data, expected_file_contents)
         filenames = ['test_rw_hexport.txt']

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -409,16 +409,16 @@ class TestRescorlaWagner(LsTestCase):
 
         self.assertIsNotNone(data)
 
-        expected_file_contents = '''"step","stimulus subject 0","response subject 0"
-0,"cs",""
-1,"us",""
-2,"cs",""
-3,"us",""
-4,"cs",""
-5,"us",""
-6,"cs",""
-7,"us",""
-8,"cs",""
+        expected_file_contents = '''"run","phase","subject","step","line","compound","behavior","cs","us"
+"run1","foo",0,1,"CS","cs","",1,0
+"run1","foo",0,2,"US","us","",0,1
+"run1","foo",0,3,"CS","cs","",1,0
+"run1","foo",0,4,"US","us","",0,1
+"run1","foo",0,5,"CS","cs","",1,0
+"run1","foo",0,6,"US","us","",0,1
+"run1","foo",0,7,"CS","cs","",1,0
+"run1","foo",0,8,"US","us","",0,1
+"run1","foo",0,9,"CS","cs","",1,0
 '''
         self.assertEqual(data, expected_file_contents)
         filenames = ['test_rw_hexport.txt']

--- a/tests/test_nplot.py
+++ b/tests/test_nplot.py
@@ -109,7 +109,7 @@ class TestInitialValues(LsTestCase):
         obj, simulation_data = run(text)
 
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's1', 'b', 's2', 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s1':1}, 'b', {'s2':1}, 'b', {'s3':1}, 'b'] * 10)
 
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -121,7 +121,7 @@ class TestInitialValues(LsTestCase):
         obj, simulation_data = run(text)
 
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's1', 'b', 's2', 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s1':1}, 'b', {'s2':1}, 'b', {'s3':1}, 'b'] * 10)
 
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -133,7 +133,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="exact", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [4, 9, 14, 19, 24, 29, 34, 39, 44, 49])
@@ -145,7 +145,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="exact", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [4, 9, 14, 19, 24, 29, 34, 39, 44, 49])
@@ -157,7 +157,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [4, 9, 14, 19, 24, 29, 34, 39, 44, 49])
@@ -170,7 +170,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -182,7 +182,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="off")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [1, 1, 1, 1, 1, 1, 1, 1, 1])
@@ -195,7 +195,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -207,7 +207,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="off")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [1, 1, 1, 1, 1, 1, 1, 1, 1])
@@ -220,7 +220,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [2, 4, 6, 8, 10, 12, 14, 16, 18, 20])
@@ -232,7 +232,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="off")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [2, 2, 2, 2, 2, 2, 2, 2, 2])
@@ -245,7 +245,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [3, 6, 9, 12, 15, 18, 21, 24, 27, 30])
@@ -257,7 +257,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="subset", cumulative="off")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [3, 3, 3, 3, 3, 3, 3, 3, 3])
@@ -268,7 +268,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="exact", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [3, 8, 13, 18, 23, 28, 33, 38, 43, 48])
@@ -280,7 +280,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="exact", cumulative="off")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [5, 5, 5, 5, 5, 5, 5, 5, 5])
@@ -292,7 +292,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="exact", cumulative="on")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [3, 8, 13, 18, 23, 28, 33, 38, 43, 48])
@@ -304,7 +304,7 @@ class TestInitialValues(LsTestCase):
                                 xscale_match="exact", cumulative="off")
         obj, simulation_data = run(text)
         history = simulation_data.run_outputs["run1"].output_subjects[0].history
-        self.assertEqual(history, ['s1', 'b', 's2', 'b', 's2', 'b', ('s1', 's2'), 'b', 's3', 'b'] * 10)
+        self.assertEqual(history, [{'s1':1}, 'b', {'s2':1}, 'b', {'s2':1}, 'b', {'s1':1, 's2':1}, 'b', {'s3':1}, 'b'] * 10)
         plot_data = get_plot_data()
         self.assertEqual(plot_data['x'], [1, 2, 3, 4, 5, 6, 7, 8, 9])
         self.assertEqual(plot_data['y'], [5, 5, 5, 5, 5, 5, 5, 5, 5])

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -1156,7 +1156,7 @@ class TestMultipleActions(LsTestCase):
         '''
         script_obj, script_output = run(text)
         history = script_output.run_outputs['foo'].output_subjects[0].history
-        self.assertEqual(history[::2], ['e1', 'e2'] * 9 + ['e1'])
+        self.assertEqual(history[::2], [{'e1':1}, {'e2':1}] * 9 + [{'e1':1}])
 
     def test_set_and_use_variable_on_same_line2(self):
         text = '''
@@ -1174,7 +1174,7 @@ class TestMultipleActions(LsTestCase):
         '''
         script_obj, script_output = run(text)
         history = script_output.run_outputs['foo'].output_subjects[0].history
-        self.assertEqual(history[::2], ['e1'] * 10)
+        self.assertEqual(history[::2], [{'e1':1}] * 10)
 
     def test_response_in_condition(self):
         text = '''

--- a/tests/test_plot_export_arithmetic.py
+++ b/tests/test_plot_export_arithmetic.py
@@ -147,12 +147,11 @@ class TestPlotExportArithmetic(LsTestCase):
         # Test contents of exported file
         file = os.path.join('.', 'tests', 'exported_files', 'expr.csv')
         exported_titles, exported_data = get_csv_file_contents(file)
-        self.assertListEqual(exported_titles, ['x', 'v(stimulus->response) + 10 * p(stimulus->response) - w(stimulus)**3 / (1 + n(stimulus->response->reward))'])
+        exported_data = [exported_data[i][4] for i in range(len(exported_data))]
         x = 0
         for v, p, w, n, exported in zip(vplot, pplot, wplot, nplot, exported_data):
             e_python = v + 10 * p - w**3 / (1 + n)
-            self.assertAlmostEqual(float(exported[0]), x)
-            self.assertAlmostEqual(float(exported[1]), e_python)
+            self.assertAlmostEqual(float(exported), e_python)
             x += 1
 
     def test_consecutive_pplot(self):
@@ -289,7 +288,7 @@ subject: average
         # Test contents of exported file
         file = os.path.join('.', 'tests', 'exported_files', 'with_var.txt')
         exported_titles, exported_data = get_csv_file_contents(file)
-        self.assertListEqual(exported_titles, ['x', 'n(s)**y + x - z * round((5+y+z) * sin(n(s)))'])
+        exported_data = [[exported_data[i][3], exported_data[i][4]] for i in range(len(exported_data))]
         self.assertListEqual(exported_data, [['0', '-1.0'], ['1', '-24.0'], ['2', '-24.0'], ['3', '5.0'], ['4', '39.0']])
 
     def test_all_math_functions(self):
@@ -345,6 +344,11 @@ subject: average
         _, hyp_export = get_csv_file_contents(os.path.join('.', 'tests', 'exported_files', 'hyp.csv'))
         _, rounding_export = get_csv_file_contents(os.path.join('.', 'tests', 'exported_files', 'rounding.csv'))
         _, other_export = get_csv_file_contents(os.path.join('.', 'tests', 'exported_files', 'other.csv'))
+
+        trig_export = [trig_export[i][4] for i in range(len(trig_export))]
+        hyp_export = [hyp_export[i][4] for i in range(len(hyp_export))]
+        rounding_export = [rounding_export[i][4] for i in range(len(rounding_export))]
+        other_export = [other_export[i][4] for i in range(len(other_export))]
         
         self.assertEqual(len(trig), len(trig_export))
         self.assertEqual(len(hyp), len(hyp_export))
@@ -354,10 +358,10 @@ subject: average
         n = 0
         for t, h, r, o, t_e, h_e, r_e, o_e, v in zip(trig, hyp, rounding, other, trig_export, hyp_export, rounding_export, other_export, vplot):
             # Exported values are strings
-            t_e = float(t_e[1])
-            h_e = float(h_e[1])
-            r_e = float(r_e[1])
-            o_e = float(o_e[1])
+            t_e = float(t_e)
+            h_e = float(h_e)
+            r_e = float(r_e)
+            o_e = float(o_e)
 
             t_python = sin(n) + cos(n) + tan(n) + asin(n / (n + 1)) + acos(n / (n + 1)) + atan(n / (n + 1))
             self.assertAlmostEqual(t_python, t)

--- a/tests/test_prev_standard_worlds.py
+++ b/tests/test_prev_standard_worlds.py
@@ -118,13 +118,14 @@ class TestClassicalConditioning(LsTestCase):
     def test_run(self):
         phase = self.phase
         s = phase.next_stimulus(None)
-        self.assertEqual(s, ({"context": 1}, 'CONTEXT', [], True))
+        # We test 0:4 here and below, leaving out an unused Variables object 
+        self.assertEqual(s[0:4], ({"context": 1}, 'CONTEXT', [], True))
 
         for _ in range(24):
             s = phase.next_stimulus('foo')
-            self.assertEqual(s, ({"context": 1}, 'CONTEXT', [], False))
+            self.assertEqual(s[0:4], ({"context": 1}, 'CONTEXT', [], False))
         s = phase.next_stimulus('foo')
-        self.assertEqual(s, ({"us": 1, "context": 1}, 'US', [], False))
+        self.assertEqual(s[0:4], ({"us": 1, "context": 1}, 'US', [], False))
 
         s = phase.next_stimulus('R')
         self.assertEqual(s[0], {"reward": 1, "context": 1})

--- a/tests/test_xscale.py
+++ b/tests/test_xscale.py
@@ -43,7 +43,7 @@ class TestSmall(LsTestCase):
         '''
         script, simulation_data = run(text)
         history = simulation_data.run_outputs['run1'].output_subjects[0].history
-        expected_history = ['s1', 'b', 's2', 'b', 's1', 'b', 's2', 'b', 's1', 'b', 's2', 'b', 's1', 'b']
+        expected_history = [{'s1':1}, 'b', {'s2':1}, 'b', {'s1':1}, 'b', {'s2':1}, 'b', {'s1':1}, 'b', {'s2':1}, 'b', {'s1':1}, 'b']
         self.assertEqual(history, expected_history)
 
         # xscale: all

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -157,11 +157,13 @@ class LsTestCase(unittest.TestCase):
 
     def assertPlotExportEqual(self, pd, exported_data):
         n_data_rows = len(exported_data)
-        print( "exported_data:", exported_data )
-        exported_exprs = list(set([exported_data[i][0] for i in range(n_data_rows)]))
-        print( "exported_exprs:", exported_exprs )
-        # The following fails for subject=='average', but we don't test that 
-        exported_subjects = list(set([int(exported_data[i][1]) for i in range(n_data_rows)]))
+        exported_exprs = list(set([exported_data[i][1] for i in range(n_data_rows)]))
+        exported_subjects = list(set([exported_data[i][2] for i in range(n_data_rows)]))
+        # convert exported_subjects to int, but handle "average" also 
+        for i in range(len(exported_subjects)):
+            if not exported_subjects[i] == "average":
+                exported_subjects[i] = int(exported_subjects[i])
+            
         print( "exported_subjects:", exported_subjects )
         for expr in exported_exprs:
             for subject_ind in exported_subjects:
@@ -171,21 +173,13 @@ class LsTestCase(unittest.TestCase):
                     if plot_legend not in pd:
                         raise Exception(f"No data for {expr} {subject_ind} in pd")
                 plot_data = pd[plot_legend]
-                print( "plot_legend:", plot_legend )
-                print( "plot_data:", plot_data )
                 data_index = list()
-                print( "subject_ind:", subject_ind )
                 for i in range(n_data_rows):
-                    print( "expr:", expr, exported_data[i][0] )
-                    print( "subject:", subject_ind == int(exported_data[i][1]) )
-                    if exported_data[i][0] == expr and int(exported_data[i][1]) == subject_ind:
+                    if exported_data[i][1] == expr and int(exported_data[i][2]) == subject_ind:
                         data_index.append(i)
-                print( "data_index:", data_index )                
                 self.assertEqual(len(data_index), len(plot_data['x']))
-                data_x = [float(exported_data[i][2]) for i in data_index]
-                print( "data_x:", data_x )
-                data_y = [float(exported_data[i][3]) for i in data_index]
-                print( "Data_y", data_y )
+                data_x = [float(exported_data[i][3]) for i in data_index]
+                data_y = [float(exported_data[i][4]) for i in data_index]
                 n_data = len(data_index)
 
                 # Check that all plot data have the same length as exported data 

--- a/util.py
+++ b/util.py
@@ -3,7 +3,7 @@ import re
 import random
 import os
 import sys
-
+import copy
 
 SEMICOLON_ERR = "Cannot use semicolon-separated expressions with wildcard."
 
@@ -1199,6 +1199,15 @@ def find_and_cumsum(seq, pattern, use_exact_match):
             else:
                 return pattern == st
 
+    # switching from storing stimuli as strings in the history to
+    # storing them as dicts broke this function, which expected
+    # stimuli as strings. this is a quick fix:
+    seq = copy.copy( seq ) # don't change original seq!
+    for i in range(len(seq)):
+        s = seq[i]
+        if type(s) is dict:
+            seq[i] = ','.join( s.keys() )
+    
     assert(type(seq) == list)
     for s in seq:
         s_type = type(s)

--- a/util.py
+++ b/util.py
@@ -1206,8 +1206,10 @@ def find_and_cumsum(seq, pattern, use_exact_match):
     for i in range(len(seq)):
         s = seq[i]
         if type(s) is dict:
-            seq[i] = ','.join( s.keys() )
-    
+            seq[i] = tuple( s.keys() )
+            if len(seq[i])==1:
+                seq[i] = seq[i][0]
+                
     assert(type(seq) == list)
     for s in seq:
         s_type = type(s)


### PR DESCRIPTION
This extends [branch 179-h-export-long](https://github.com/learningsimulator/learningsimulator/pull/203) to cover export of v, w, p, and n. All of the exported CSV files have the same format with columns run, expr, subject, step, value, where run is the run label, expr the expression being exported (for example, w(stimulus)), subject the subject index, or "average", step the evaluation step, and value the expression's value.

These updates are in parsing.py, with a number of changes to tests to reflect the new format.

I will update the docs shortly. I will also work to include phase labels in the output (like in the long-form history export).