### PR TITLE
Support gzip-compressed CSV export

### DIFF
--- a/docs/filename.txt
+++ b/docs/filename.txt
@@ -34,3 +34,10 @@ Description
 .. note::
 
   If the specified file already exists, the existing file will be overwritten without warning.
+
+.. note::
+
+  If the filename ends with ``.gz`` (for example ``my_file.csv.gz``), the exported file will be
+  automatically compressed using gzip. This can significantly reduce file size for large datasets.
+  Most data analysis tools (such as pandas and R) can read ``.csv.gz`` files directly without
+  manual decompression.

--- a/parsing.py
+++ b/parsing.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
 import csv
+import gzip
 import json
 import math
 
@@ -1300,7 +1301,10 @@ class ExportCmd(PostCmd):
             raise ParseException(self.lineno, f"Parameter {kw.EVAL_FILENAME} to {self.cmd} is mandatory.")
         # if not filename.endswith(".csv"):
         #     filename = filename + ".csv"
-        file = open(filename, 'w', newline='')
+        if filename.endswith('.gz'):
+            file = gzip.open(filename, 'wt', newline='')
+        else:
+            file = open(filename, 'w', newline='')
 
         try:
             if self.cmd == kw.HEXPORT:

--- a/tests/test_export_multi.py
+++ b/tests/test_export_multi.py
@@ -596,6 +596,58 @@ class TestExportMultiExpression(LsTestCase):
 
 
 
+class TestExportGzip(LsTestCase):
+    def setUp(self):
+        create_exported_files_folder()
+
+    def tearDown(self):
+        plt.close('all')
+        filenames = ['vexport_gz.csv.gz', 'vexport_plain.csv']
+        remove_exported_files(filenames)
+        self.assert_exported_files_are_removed(filenames)
+        delete_exported_files_folder()
+
+    def test_gzip_export(self):
+        text = """
+        n_subjects        = 1
+        mechanism         = a
+        behaviors         = response, no_response
+        stimulus_elements = background, stimulus, reward
+        start_v           = -1
+        alpha_v           = 0.1
+        alpha_w           = 1
+        u                 = reward:10, default:0
+
+        @PHASE training stop: stimulus==3
+        START       stimulus   | response: REWARD | NO_REWARD
+        REWARD      reward     | @omit_learn, START
+        NO_REWARD   background | @omit_learn, START
+
+        @run training
+
+        xscale: stimulus
+        subject: 1
+
+        filename: ./tests/exported_files/vexport_gz.csv.gz
+        @vexport stimulus->response
+
+        filename: ./tests/exported_files/vexport_plain.csv
+        @vexport stimulus->response
+        """
+        run(text)
+
+        gz_file = os.path.join('.', 'tests', 'exported_files', 'vexport_gz.csv.gz')
+        plain_file = os.path.join('.', 'tests', 'exported_files', 'vexport_plain.csv')
+
+        gz_titles, gz_data = get_csv_file_contents(gz_file)
+        plain_titles, plain_data = get_csv_file_contents(plain_file)
+
+        self.assertListEqual(gz_titles, plain_titles)
+        self.assertEqual(len(gz_data), len(plain_data))
+        for gz_row, plain_row in zip(gz_data, plain_data):
+            self.assertListEqual(gz_row, plain_row)
+
+
 class TestExceptions(LsTestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -93,7 +93,12 @@ def get_plot_data(figure_number=1, axes_number=1):
 
 def get_csv_file_contents(file):
     data = None
-    with open(file) as f:
+    if file.endswith('.gz'):
+        import gzip
+        f = gzip.open(file, 'rt')
+    else:
+        f = open(file)
+    with f:
         reader = csv.reader(f)
         data = list(reader)
     titles = data[0]


### PR DESCRIPTION
## Summary
- Automatically gzip-compress exported CSV files when the filename ends with `.gz` (e.g., `filename: results.csv.gz`)
- No new keywords needed — compression is detected from the file extension
- Updated `filename` documentation with a note about `.gz` support

## Test plan
- [x] New test verifies `.csv.gz` and `.csv` exports produce identical data
- [x] Existing export tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)